### PR TITLE
BUGFIX: Fix type so that plugin is installed in the correct directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "shopwareLabs/swag-user-price",
-  "type": "shopware-plugin",
+  "type": "shopware-backend-plugin",
   "description": "Customer specific prices in Shopware",
   "license": "MIT",
   "extra": {


### PR DESCRIPTION
The shopware composer project skeleton already knows the type "shopware-backend-plugin" to install legacy plugins in the correct location.
(cf. https://github.com/shopware/composer-project/blob/master/composer.json)