### PR TITLE
fix ordering of block prices in `ServiceHelper.getPrices`

### DIFF
--- a/Components/ServiceHelper.php
+++ b/Components/ServiceHelper.php
@@ -61,7 +61,7 @@ class ServiceHelper
      */
     public function getPrices($number)
     {
-        return $this->getPricesQueryBuilder($number)->execute()->fetchAll();
+        return $this->getPricesQueryBuilder($number)->orderBy('prices.from', 'ASC')->execute()->fetchAll();
     }
 
     /**


### PR DESCRIPTION
The current implementation depends on the "default" ordering returned by the database, which fortunately seems ordered by id (or creation order). This works for Prices created by the backend, as it forces creation in the correct order (small `from` quantities before larger `from` quantities).
This pull request adds the missing ordering by `from` quantity to `ServiceHelper.getPrices`. The ordering is already in place in `Models\UserPrice\Repository.getPricesQueryBuilder`, so all backend controllers should already work as intended.

We encountered this problem adding prices using an api endpoint, currently implemented in a plugin.
If the prices were created out of order (in respect to the `from` quantity), the order in the frontend article detail view is incorrect..