### PR TITLE
Fixes issues on Cronjob

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -8,6 +8,10 @@
 use Shopware\SwagUserPrice\Bootstrap\Setup;
 use Shopware\SwagUserPrice\Bundle\SearchBundleDBAL\PriceHelper;
 use Shopware\SwagUserPrice\Bundle\StoreFrontBundle\Service\Core;
+use Shopware\SwagUserPrice\Bundle\StoreFrontBundle\Service\DependencyProvider;
+use Shopware\SwagUserPrice\Components\AccessValidator;
+use Shopware\SwagUserPrice\Components\ServiceHelper;
+use Shopware\SwagUserPrice\Components\UserPrice;
 use Shopware\SwagUserPrice\Subscriber;
 
 /**
@@ -204,6 +208,39 @@ class Shopware_Plugins_Backend_SwagUserPrice_Bootstrap extends Shopware_Componen
 
         $userPriceService = new Core\GraduatedUserPricesService($coreService, $validator, $helper);
         Shopware()->Container()->set('shopware_storefront.graduated_prices_service', $userPriceService);
+    }
+
+
+    /**
+     * @return DependencyProvider
+     */
+    public function onGetDependencyProvider()
+    {
+        return new DependencyProvider($this->get('service_container'));
+    }
+
+    /**
+     * @return UserPrice
+     */
+    public function onGetUserPriceComponent()
+    {
+        return new UserPrice();
+    }
+
+    /**
+     * @return AccessValidator
+     */
+    public function onGetAccessValidator()
+    {
+        return new AccessValidator();
+    }
+
+    /**
+     * @return ServiceHelper
+     */
+    public function onGetServiceHelper()
+    {
+        return new ServiceHelper();
     }
 
     /**

--- a/Bootstrap/Setup.php
+++ b/Bootstrap/Setup.php
@@ -113,6 +113,10 @@ class Setup
             'Enlight_Bootstrap_AfterInitResource_shopware_searchdbal.search_price_helper_dbal' => 'registerPriceHelper',
             'Enlight_Bootstrap_AfterInitResource_shopware_storefront.cheapest_price_service' => 'onGetCheapestPriceService',
             'Enlight_Bootstrap_AfterInitResource_shopware_storefront.graduated_prices_service' => 'onGetGraduatedPricesService',
+            'Enlight_Bootstrap_InitResource_swaguserprice.userprice' => 'onGetUserPriceComponent',
+            'Enlight_Bootstrap_InitResource_swaguserprice.accessvalidator' => 'onGetAccessValidator',
+            'Enlight_Bootstrap_InitResource_swaguserprice.servicehelper' => 'onGetServiceHelper',
+            'Enlight_Bootstrap_InitResource_swaguserprice.dependency_provider' => 'onGetDependencyProvider',
         ];
 
         foreach ($events as $event => $listener) {


### PR DESCRIPTION
Fixes an issue when requesting the
`storefront.graduated_prices_service`-service on cronjob.

Due to the `createEvents()` method, this service is being extended
by the plugin. However, it causes an ugly crash because its
dependencies, e.g. service `swaguserprice.userprice` are not loaded
or registered at cronjob. This ensures these services are
available and that the decoration of the storefront-services
succeeds.